### PR TITLE
Compatibility with piler 1.4.7

### DIFF
--- a/auth-mailcow.php
+++ b/auth-mailcow.php
@@ -84,7 +84,7 @@ function query_mailcow_for_email_access($username = '')
 function mailcow_get_mailbox_realname($mailbox = '')
 {
 	// let's check if mailbox provided
-	if ($mailbox !== '') {
+	if ($mailbox === '') {
 		return null;
 	}
 

--- a/auth-mailcow.php
+++ b/auth-mailcow.php
@@ -54,6 +54,8 @@ function query_mailcow_for_email_access($username = '')
 			unset($emails[$i]); // lets be memory efficient
 		}
 	}
+
+	// with piler 1.4.7 this is deprecated and should be removed in the future
 	$data['emails'] = array_merge($data['emails'] , $emails);
 
 	// set realname, if available.
@@ -71,6 +73,9 @@ function query_mailcow_for_email_access($username = '')
 	// Released in piler 1.3.10.
 	$session->set('wildcard_domains', $wildcards);
 	$session->set('auth_data', $data);
+	
+	// starting with piler 1.4.7 function need to return an array of emails
+	return $emails;
 }
 
 // mailcow_get_aliases($mailbox) returns back the name of the


### PR DESCRIPTION
With piler 1.4.7 they changed the way how CUSTOM_EMAIL_QUERY_FUNCTION is used. It expects a array of emails.
In 1.4.7 there is no way to set realname without changing interface of piler.

[Here](https://github.com/jsuto/piler/blob/874c0a69ea2d11932e7871318870a90bcc267373/webui/model/user/auth.php#L409C41-L409C68) you can find the code change in auth.php